### PR TITLE
Onboarding pages of SNAPP should always open in standard window mode

### DIFF
--- a/.testcafe-electron-rc.js
+++ b/.testcafe-electron-rc.js
@@ -21,6 +21,7 @@ if (platform === LINUX) {
 
 if (platform === WINDOWS) {
     PLATFORM_NAME = 'win-unpacked';
+    appString = 'SAFE Network App.exe';
 }
 
 let config = {

--- a/app/components/OnBoarding/BasicSettings/BasicSettings.tsx
+++ b/app/components/OnBoarding/BasicSettings/BasicSettings.tsx
@@ -9,6 +9,7 @@ import styles from './BasicSettings.css';
 
 import { UserPreferences } from '$Definitions/application.d';
 import { Preferences } from '$Components/Preferences';
+import { defaultPreferences } from '$Constants/index';
 
 interface Props {
     userPreferences: UserPreferences;
@@ -41,7 +42,7 @@ export const BasicSettings = ( properties ) => {
             <Grid item xs={12}>
                 <Preferences
                     isTrayWindow={isTrayWindow}
-                    userPreferences={userPreferences}
+                    userPreferences={defaultPreferences.userPreferences}
                     requiredItems={requiredItems}
                     onChange={setUserPreferences}
                 />

--- a/app/components/OnBoarding/OnBoarding.tsx
+++ b/app/components/OnBoarding/OnBoarding.tsx
@@ -42,6 +42,11 @@ export class OnBoarding extends React.Component<Props> {
 
     totalSteps = 3;
 
+    componentDidMount() {
+        const { triggerSetAsTrayWindow } = this.props;
+        triggerSetAsTrayWindow( false );
+    }
+
     navigate = ( position ) => {
         const { history } = this.props;
         enum ON_BOARDING_PAGES {

--- a/app/manageInstallations/uninstall.ts
+++ b/app/manageInstallations/uninstall.ts
@@ -53,22 +53,22 @@ export const unInstallApplication = async (
         );
     }
 
-    if ( isRunningOnWindows && isDryRun ) {
-        logger.info(
-            `DRY RUN: Would have uninstalled via command: "${windowsUninstallLocation} /S"`
-        );
-    }
-
     if ( isRunningOnWindows ) {
-        const uninstalled = spawnSync( windowsUninstallLocation, ['/S'] );
+        if ( isDryRun )
+            logger.info(
+                `DRY RUN: Would have uninstalled via command: "${windowsUninstallLocation} /S"`
+            );
+        else {
+            const uninstalled = spawnSync( windowsUninstallLocation, ['/S'] );
 
-        if ( uninstalled.error ) {
-            logger.error( 'Error during uninstall', uninstalled.error );
+            if ( uninstalled.error ) {
+                logger.error( 'Error during uninstall', uninstalled.error );
+            }
+
+            // ? ALSO: ~/AppData/Local/safe-launchpad-updater
+
+            return;
         }
-
-        // ? ALSO: ~/AppData/Local/safe-launchpad-updater
-
-        return;
     }
 
     try {

--- a/app/setupLaunchPad.ts
+++ b/app/setupLaunchPad.ts
@@ -184,7 +184,7 @@ export const createSafeLaunchPadTrayWindow = (
             showAsTrayWindow();
         } else {
             // must be first for dock icon changes
-            tray.destroy();
+            if ( tray ) tray.destroy();
             store.dispatch( setAsTrayWindow( false ) );
             showAsRegularWindow();
         }


### PR DESCRIPTION
resolves #121 