### PR TITLE
Close app on windows/linux properly

### DIFF
--- a/app/main.development.ts
+++ b/app/main.development.ts
@@ -17,6 +17,8 @@ import { checkForKnownAppsLocally } from '$App/manageInstallations/helpers';
 import {
     isRunningTestCafeProcess,
     isRunningUnpacked,
+    isRunningOnLinux,
+    isRunningOnWindows,
     getAppFolderPath,
     platform,
     settingsHandlerName
@@ -89,7 +91,7 @@ if ( !gotTheLock ) {
                     app.hide();
                 else theWindow.hide();
             }
-            if ( process.platform === 'win32' || process.platform === 'linux' )
+            if ( isRunningOnWindows || isRunningOnLinux )
                 app.quit();
         } );
 

--- a/app/main.development.ts
+++ b/app/main.development.ts
@@ -89,6 +89,8 @@ if ( !gotTheLock ) {
                     app.hide();
                 else theWindow.hide();
             }
+            if ( process.platform === 'win32' || process.platform === 'linux' )
+                app.quit();
         } );
 
         const menuBuilder = new MenuBuilder( theWindow, store );


### PR DESCRIPTION
The current dev branch only closes the tray/standard window mode app but not the background process, hence the app does not quit properly on win and Linux
